### PR TITLE
Remove wrong ORCID and fix author names

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,28 @@
 cff-version: 1.0.0
 message: "If you use this software, please cite it as below."
 authors:
-  - family-names: Peres, Lees, Rodriguez, Lee, Polak, Hope, Collins, Ohlin, Kleinstein, Watson, Yaari
-    given-names: Ayelet, William, Oscar L., Noah Y., Pazit, Ronen, Andrew, Mats, Steven H., Corey, Gur
-    orcid: https://orcid.org/0000-0003-4925-7248
+  - family-names: Peres
+    given-names: Ayelet
+  - family-names: Lees
+    given-names: William
+  - family-names: Rodriguez
+    given-names: Oscar L.
+  - family-names: Lee
+    given-names: Noah Y.
+  - family-names: Polak
+    given-names: Pazit
+  - family-names: Hope
+    given-names: Ronen
+  - family-names: Collins
+    given-names: Andrew
+  - family-names: Ohlin
+    given-names: Mats
+  - family-names: Kleinstein
+    given-names: Steven H.
+  - family-names: Watson
+    given-names: Corey
+  - family-names: Yaari
+    given-names: Gur
 title: "Allele similarity cluster archive for IGHV alleles germline set"
 version: 1.0.0
 doi: 10.5281/zenodo.7401190


### PR DESCRIPTION
- This file was apparently copied from a template that contained my real ORCID (my fault), and therefore this release linked to my ORCID record. Removed the `orcid` field.
- Also fixed the author names so that the name fields are used as intended.
- For more info, please see the CFF documentation at https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md.
- You can also use a GitHub Action to validate the CFF file automatically in continuous integration, see https://github.com/marketplace/actions/cffconvert.